### PR TITLE
GAのタグをNext.jsのサンプルを参考に追加した

### DIFF
--- a/lib/gtag.js
+++ b/lib/gtag.js
@@ -1,0 +1,17 @@
+export const GA_TRACKING_ID = "UA-172531907-1";
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export const pageview = (url) => {
+  window.gtag("config", GA_TRACKING_ID, {
+    page_path: url,
+  });
+};
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({ action, category, label, value }) => {
+  window.gtag("event", action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  });
+};

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useEffect } from "react";
 import Head from "next/head";
 import { AppProps } from "next/app";
 import { createMuiTheme, makeStyles } from "@material-ui/core/styles";
@@ -6,6 +6,8 @@ import { ThemeProvider } from "@material-ui/styles";
 import { cyan } from "@material-ui/core/colors";
 import Header from "../components/Header";
 import "highlight.js/styles/github.css";
+import { pageview } from "../lib/gtag";
+import Router from "next/router";
 
 const theme = createMuiTheme({
   palette: {
@@ -27,6 +29,15 @@ const useStyles = makeStyles({
 
 const App: FC<AppProps> = ({ Component, pageProps }) => {
   const classes = useStyles();
+  useEffect(() => {
+    const handleRouteChange = (url) => {
+      pageview(url);
+    };
+    Router.events.on("routeChangeComplete", handleRouteChange);
+    return () => {
+      Router.events.off("routeChangeComplete", handleRouteChange);
+    };
+  }, []);
 
   return (
     <>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,12 +1,30 @@
 import React from "react";
 import Document, { Html, Head, Main, NextScript } from "next/document";
 import { ServerStyleSheets } from "@material-ui/core/styles";
+import { GA_TRACKING_ID } from "../lib/gtag";
 
 export default class MyDocument extends Document {
   render() {
     return (
       <Html lang="en">
         <Head>
+          {/* Global Site Tag (gtag.js) - Google Analytics */}
+          <script
+            async
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+          />
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${GA_TRACKING_ID}', {
+              page_path: window.location.pathname,
+            });
+          `,
+            }}
+          />
           {/* PWA primary color */}
           {/* <meta name="theme-color" content={theme.palette.primary.main} /> */}
           <link


### PR DESCRIPTION
参考にしたのはこれ
https://github.com/vercel/next.js/tree/canary/examples/with-google-analytics
